### PR TITLE
fix: package requirements

### DIFF
--- a/devcontainer.el
+++ b/devcontainer.el
@@ -4,7 +4,6 @@
 
 ;; Author: Lina Bhaile <emacs-devel@linabee.uk>
 ;; Version: 1.0
-;; Package-Requires: (tramp cl-lib)
 ;; Keywords: comm processes tools unix
 ;; URL: https://github.com/lina-bh/devcontainer.el
 


### PR DESCRIPTION
Remove the "Package-Requires" line as it breaks installation with package-vc-install. tramp and cl-lib are built-in packages, so this statement doesn't seem to be necessary anyway (as an example, [dape](https://github.com/svaante/dape) doesn't include it, despite [using tramp](https://github.com/svaante/dape/blob/b3b15053ea19821205f43528b61cc2d9e0a4a21a/dape.el#L58)).

An alternative to this would be to "specify" the versions, according to [package-lint](https://github.com/purcell/package-lint). For me, cl-lib is at 1.0, while tramp is at 0.

- Emacs version: `GNU Emacs 31.0.50 (build 1, x86_64-pc-linux-gnu, GTK+ Version 3.24.43, cairo version 1.18.2)`
- Emacs commit: https://github.com/emacs-mirror/emacs/commit/c801856820c17247416846ac565b81268b4aca16